### PR TITLE
Added javadoc and source generation for jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,34 @@
         </executions>
       </plugin>
 
+      <!-- Compile jar with sources -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- Compile jar with javadocs -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
       <!-- Coveralls.io test coverage -->
       <plugin>
         <groupId>org.eluder.coveralls</groupId>


### PR DESCRIPTION
The proposed change triggers maven to build jars containing the source/javadocs.

Merging will be no problem, but due to existing code comments that are not in line with javadoc, there will be warnings and/or errors.

I fixed those in a lot of minor commits on my fork, but I am not sure whether my changes would be considered in-line with the LogicNG style. Therefore someone would have to re-do them. This is the down-side of this pull request.

On the other hand adding this to the pom also leads to further checks of the source code comments. Problems like forgotten @param annotations will now be visible. It should therefore improve the overall comment quality of LogicNG.

I propose this pull because I am getting tired of fixing small issues in comments.