### PR TITLE
Zero Coefficients in PBC

### DIFF
--- a/src/main/java/org/logicng/formulas/PBConstraint.java
+++ b/src/main/java/org/logicng/formulas/PBConstraint.java
@@ -106,7 +106,7 @@ public final class PBConstraint extends Formula {
     for (final int c : coefficients) {
       if (c > this.maxWeight)
         this.maxWeight = c;
-      if (c != 1)
+      if (c != 1 && c != 0)
         cc = false;
     }
     for (final Literal lit : literals)

--- a/src/test/java/org/logicng/formulas/PBConstraintTest.java
+++ b/src/test/java/org/logicng/formulas/PBConstraintTest.java
@@ -57,6 +57,7 @@ public class PBConstraintTest {
 
   private final PBConstraint pb1;
   private final PBConstraint pb2;
+  private final PBConstraint pb3;
   private final PBConstraint pb22;
   private final PBConstraint cc1;
   private final PBConstraint cc2;
@@ -71,8 +72,10 @@ public class PBConstraintTest {
     final List<Variable> litsCC2 = Arrays.asList(f.variable("a"), f2.variable("b"), f.variable("c"));
     final int[] coeffs1 = new int[]{3};
     final List<Integer> coeffs2 = Arrays.asList(3, -2, 7);
+    final List<Integer> coeffsCC3 = Arrays.asList(0, 1, 1);
     this.pb1 = f.pbc(CType.LE, 2, lits1, coeffs1);
     this.pb2 = f.pbc(CType.LE, 8, lits2, coeffs2);
+    this.pb3 = f.pbc(CType.GT, 2, litsCC2, coeffsCC3);
     this.pb22 = f2.pbc(CType.LE, 8, lits2, coeffs2);
     this.cc1 = f.cc(CType.LT, 1, lits1);
     this.cc2 = f.cc(CType.GE, 2, litsCC2);
@@ -108,6 +111,7 @@ public class PBConstraintTest {
     final Literal[] litsCC2 = new Literal[]{f.variable("a"), f.variable("b"), f2.variable("c")};
     final int[] coeffs1 = new int[]{3};
     final int[] coeffs2 = new int[]{3, -2, 7};
+    final int[] coeffs3 = {0, 1, 1};
 
     final int[] coeffsCC1 = new int[]{1};
     final int[] coeffsCC2 = new int[]{1, 1, 1};
@@ -125,6 +129,13 @@ public class PBConstraintTest {
     Assert.assertEquals(8, this.pb2.rhs());
     Assert.assertFalse(this.pb2.isCC());
     Assert.assertEquals(7, this.pb2.maxWeight());
+
+    Assert.assertArrayEquals(litsCC2, this.pb3.operands());
+    Assert.assertArrayEquals(coeffs3, this.pb3.coefficients());
+    Assert.assertEquals(CType.GT, this.pb3.comparator());
+    Assert.assertEquals(2, this.pb3.rhs());
+    Assert.assertTrue(this.pb3.isCC());
+    Assert.assertEquals(1, this.pb3.maxWeight());
 
     Assert.assertArrayEquals(lits1, this.cc1.operands());
     Assert.assertArrayEquals(coeffsCC1, this.cc1.coefficients());


### PR DESCRIPTION
Hello everyone,

I was looking into PBCs a little bit more and the way zero coefficients are currently handeled can be improved in my oppinion. Instead of proposing a big change here, I wanted to start with a small thing:

(1a + 1b + 1c < 2) is a cardinality constraint, as we probably all agree and is currently implemented. However I think (0a + 1b + 1c < 2) is also a cardinality constraint. The value of a doesn't matter at all anymore. We _could_ catch those zero-coefficient cases and return smaler pbc's in general, however this might get messy. Instead I would simply want to allow zero coefficients in CCs. They are allowed in PBCs anyway currently.

Here is the proposed change: