### PR TITLE
Updated antlr dependencies from 4.9.3 to 4.13.1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,13 +75,13 @@
     <sonar.exclusions>**/LogicNGPropositional*.java,**/LogicNGPseudoBoolean*.java</sonar.exclusions>
 
     <!-- Dependency Versions -->
-    <version.antlr>4.11.1</version.antlr>
+    <version.antlr>4.13.1</version.antlr>
     <version.junit>5.9.2</version.junit>
     <version.assertj>3.24.2</version.assertj>
     <version.mockito>5.2.0</version.mockito>
 
     <!-- Plugin Versions -->
-    <version.antlr-plugin>4.11.1</version.antlr-plugin>
+    <version.antlr-plugin>4.13.1</version.antlr-plugin>
     <version.jacoco>0.8.8</version.jacoco>
     <version.coveralls>4.3.0</version.coveralls>
     <version.surefire>3.0.0-M9</version.surefire>

--- a/src/main/antlr/LogicNGPropositional.g4
+++ b/src/main/antlr/LogicNGPropositional.g4
@@ -32,7 +32,7 @@ options {
   superClass = ParserWithFormula;
 }
 
-@parser::header {
+@header {
   package org.logicng.io.parsers;
 
   import java.util.LinkedHashSet;
@@ -43,12 +43,6 @@ options {
   public Formula getParsedFormula() {
     return formula().f;
   }
-}
-
-@lexer::header {
-  package org.logicng.io.parsers;
-
-  import org.logicng.formulas.FormulaFactory;
 }
 
 formula returns [Formula f]

--- a/src/main/antlr/LogicNGPseudoBoolean.g4
+++ b/src/main/antlr/LogicNGPseudoBoolean.g4
@@ -32,7 +32,7 @@ options {
   superClass = ParserWithFormula;
 }
 
-@parser::header {
+@header {
   package org.logicng.io.parsers;
 
   import java.util.LinkedHashSet;
@@ -43,12 +43,6 @@ options {
   public Formula getParsedFormula() {
     return formula().f;
   }
-}
-
-@lexer::header {
-  package org.logicng.io.parsers;
-
-  import org.logicng.formulas.FormulaFactory;
 }
 
 formula returns [Formula f]


### PR DESCRIPTION
As described in issue https://github.com/logic-ng/LogicNG/issues/48 this PR will bump up LogicNG antlr dependencies.

I faced an issue that the generated LogicNGPropositionalListener and LogicNGPseudoBooleanListener was not generated with a proper package name. I generalised the configuration in order to overcome that.